### PR TITLE
Implementation of QR reader for inviting contacts

### DIFF
--- a/surespot/build.gradle
+++ b/surespot/build.gradle
@@ -62,4 +62,6 @@ dependencies {
     compile files('libs/google-oauth-client-1.17.0-rc.jar')
     //compile files('libs/jsr305-1.3.9.jar')
     compile 'io.socket:socket.io-client:0.7.0'
+    compile 'com.journeyapps:zxing-android-embedded:3.0.2@aar'
+    compile 'com.google.zxing:core:3.2.0'
 }

--- a/surespot/src/main/java/com/twofours/surespot/activities/MainActivity.java
+++ b/surespot/src/main/java/com/twofours/surespot/activities/MainActivity.java
@@ -30,6 +30,7 @@ import android.text.TextWatcher;
 import android.text.method.TextKeyListener;
 import android.util.Log;
 import android.view.KeyEvent;
+import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
@@ -52,6 +53,7 @@ import android.widget.TextView.OnEditorActionListener;
 
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
+import com.google.zxing.integration.android.IntentIntegrator;
 import com.twofours.surespot.R;
 import com.twofours.surespot.SurespotApplication;
 import com.twofours.surespot.billing.BillingActivity;
@@ -1901,6 +1903,11 @@ public class MainActivity extends Activity implements OnMeasureListener {
                     }
                 }
             }));
+        }else{
+            // Button has been pressed with no text in the invite field
+            // Launch QR reader to scan code
+            mDialog = UIUtils.showQRReaderDialog(MainActivity.this);
+
         }
     }
 

--- a/surespot/src/main/java/com/twofours/surespot/activities/MainActivity.java
+++ b/surespot/src/main/java/com/twofours/surespot/activities/MainActivity.java
@@ -41,6 +41,7 @@ import android.view.View.OnTouchListener;
 import android.view.ViewTreeObserver.OnGlobalLayoutListener;
 import android.view.WindowManager;
 import android.view.WindowManager.LayoutParams;
+import android.view.animation.TranslateAnimation;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.AdapterView;
@@ -1137,26 +1138,31 @@ public class MainActivity extends Activity implements OnMeasureListener {
                 break;
 
             case SurespotConstants.IntentRequestCodes.QR_CODE_NOTIFICATION:
-                IntentResult scanResult = IntentIntegrator.parseActivityResult(requestCode, resultCode, data);
+                if (resultCode == Activity.RESULT_OK ){
+                    IntentResult scanResult = IntentIntegrator.parseActivityResult(requestCode, resultCode, data);
 
-                String autoInvitePath = SurespotConfiguration.getBaseUrl().replaceFirst(":\\d+", "") + "/autoinvite/";
-                if (scanResult != null && scanResult.getContents().contains(autoInvitePath)){
-                    //Use the data from the QR Code to initiate a friend request
-                    String qrContents = scanResult.getContents();
-                    int usernameEnd = qrContents.indexOf("/qr");
-                    String qrUsername = qrContents.substring(autoInvitePath.length() ,usernameEnd);
+                    if (scanResult != null && scanResult.getContents() != null){
+                        if (scanResult.getContents().contains(SurespotConstants.Url.INVITE_URL)){
+                            // We have scanned a QR code that contains a surespot URL
+                            // Use the data from the QR Code to initiate a friend request
+                            String qrContents = scanResult.getContents();
+                            int usernameEnd = qrContents.indexOf("/qr");
+                            String qrUsername = qrContents.substring(SurespotConstants.Url.INVITE_URL.length() ,usernameEnd);
 
-                    mEtInvite.setText(qrUsername);
-                    inviteFriend();
+                            mEtInvite.setText(qrUsername);
+                            inviteFriend();
 
-                    //Reset the text field for cases where user invite is not completed
-                    mEtInvite.setText("");
+                            //Reset the text field for cases where user invite is not completed
+                            mEtInvite.setText("");
+                        }else{
+                            //An invalid QR code has been scanned and should be ignored
+                            Utils.makeToast(MainActivity.this, getString(R.string.qr_scan_invalid));
+                        }
+                    }
                 }
-
             default:
                 super.onActivityResult(requestCode, resultCode, data);
         }
-
     }
 
     private void uploadPicture(final Uri selectedImageUri, String to) {
@@ -1927,7 +1933,6 @@ public class MainActivity extends Activity implements OnMeasureListener {
             // Button has been pressed with no text in the invite field
             // Launch QR reader to scan code
             UIUtils.showQRScanner(MainActivity.this);
-
         }
     }
 

--- a/surespot/src/main/java/com/twofours/surespot/activities/MainActivity.java
+++ b/surespot/src/main/java/com/twofours/surespot/activities/MainActivity.java
@@ -54,6 +54,7 @@ import android.widget.TextView.OnEditorActionListener;
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
 import com.google.zxing.integration.android.IntentIntegrator;
+import com.google.zxing.integration.android.IntentResult;
 import com.twofours.surespot.R;
 import com.twofours.surespot.SurespotApplication;
 import com.twofours.surespot.billing.BillingActivity;
@@ -1133,6 +1134,25 @@ public class MainActivity extends Activity implements OnMeasureListener {
                     // TODO upload token to server
                     SurespotLog.d(TAG, "onActivityResult handled by IABUtil.");
                 }
+                break;
+
+            case SurespotConstants.IntentRequestCodes.QR_CODE_NOTIFICATION:
+                IntentResult scanResult = IntentIntegrator.parseActivityResult(requestCode, resultCode, data);
+
+                String autoInvitePath = SurespotConfiguration.getBaseUrl().replaceFirst(":\\d+", "") + "/autoinvite/";
+                if (scanResult != null && scanResult.getContents().contains(autoInvitePath)){
+                    //Use the data from the QR Code to initiate a friend request
+                    String qrContents = scanResult.getContents();
+                    int usernameEnd = qrContents.indexOf("/qr");
+                    String qrUsername = qrContents.substring(autoInvitePath.length() ,usernameEnd);
+
+                    mEtInvite.setText(qrUsername);
+                    inviteFriend();
+
+                    //Reset the text field for cases where user invite is not completed
+                    mEtInvite.setText("");
+                }
+
             default:
                 super.onActivityResult(requestCode, resultCode, data);
         }
@@ -1906,7 +1926,7 @@ public class MainActivity extends Activity implements OnMeasureListener {
         }else{
             // Button has been pressed with no text in the invite field
             // Launch QR reader to scan code
-            mDialog = UIUtils.showQRReaderDialog(MainActivity.this);
+            UIUtils.showQRScanner(MainActivity.this);
 
         }
     }

--- a/surespot/src/main/java/com/twofours/surespot/ui/UIUtils.java
+++ b/surespot/src/main/java/com/twofours/surespot/ui/UIUtils.java
@@ -53,6 +53,7 @@ import android.widget.ImageView;
 import android.widget.RemoteViews;
 import android.widget.TextView;
 
+import com.google.zxing.integration.android.IntentIntegrator;
 import com.twofours.surespot.R;
 import com.twofours.surespot.activities.MainActivity;
 import com.twofours.surespot.backup.ExportIdentityActivity;
@@ -360,6 +361,27 @@ public class UIUtils {
         AlertDialog dialog = builder.create();
         dialog.setView(dialogLayout, 0, 0, 0, 0);
         dialog.show();
+        return dialog;
+    }
+
+    public static AlertDialog showQRReaderDialog(Activity activity){
+        LayoutInflater inflater = activity.getLayoutInflater();
+        View scannerLayout = inflater.inflate(R.layout.qr_reader_layout, null, false);
+
+        AlertDialog.Builder builder = new AlertDialog.Builder(activity).setTitle(null);
+        AlertDialog dialog = builder.create();
+        dialog.setView(scannerLayout, 0, 0, 0, 0);
+
+        IntentIntegrator integrator = new IntentIntegrator(activity);
+        integrator.setDesiredBarcodeFormats(IntentIntegrator.QR_CODE_TYPES);
+
+        
+
+        integrator.setPrompt("Scan users QR code");
+        integrator.initiateScan();
+
+        dialog.show();
+
         return dialog;
     }
 

--- a/surespot/src/main/java/com/twofours/surespot/ui/UIUtils.java
+++ b/surespot/src/main/java/com/twofours/surespot/ui/UIUtils.java
@@ -30,6 +30,7 @@ import android.graphics.Point;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.support.v4.app.NotificationCompat;
+import android.test.ActivityInstrumentationTestCase2;
 import android.text.Html;
 import android.text.InputFilter;
 import android.text.InputType;
@@ -364,25 +365,14 @@ public class UIUtils {
         return dialog;
     }
 
-    public static AlertDialog showQRReaderDialog(Activity activity){
-        LayoutInflater inflater = activity.getLayoutInflater();
-        View scannerLayout = inflater.inflate(R.layout.qr_reader_layout, null, false);
-
-        AlertDialog.Builder builder = new AlertDialog.Builder(activity).setTitle(null);
-        AlertDialog dialog = builder.create();
-        dialog.setView(scannerLayout, 0, 0, 0, 0);
-
+    public static void showQRScanner(Activity activity){
         IntentIntegrator integrator = new IntentIntegrator(activity);
         integrator.setDesiredBarcodeFormats(IntentIntegrator.QR_CODE_TYPES);
-
-        
 
         integrator.setPrompt("Scan users QR code");
         integrator.initiateScan();
 
-        dialog.show();
 
-        return dialog;
     }
 
     public static AlertDialog showHelpDialog(final Activity activity, int titleStringId, View view, final boolean firstTime) {

--- a/surespot/src/main/java/com/twofours/surespot/ui/UIUtils.java
+++ b/surespot/src/main/java/com/twofours/surespot/ui/UIUtils.java
@@ -368,8 +368,9 @@ public class UIUtils {
     public static void showQRScanner(Activity activity){
         IntentIntegrator integrator = new IntentIntegrator(activity);
         integrator.setDesiredBarcodeFormats(IntentIntegrator.QR_CODE_TYPES);
-
         integrator.setPrompt("Scan contact QR code");
+        integrator.setBeepEnabled(false);
+
         integrator.initiateScan();
     }
 

--- a/surespot/src/main/java/com/twofours/surespot/ui/UIUtils.java
+++ b/surespot/src/main/java/com/twofours/surespot/ui/UIUtils.java
@@ -314,7 +314,7 @@ public class UIUtils {
 
     private static String buildExternalInviteUrl(String username) {
         try {
-            return "https://server.surespot.me/autoinvite/" + URLEncoder.encode(username, "UTF-8") + "/social";
+            return SurespotConstants.Url.INVITE_URL + URLEncoder.encode(username, "UTF-8") + "/social";
         }
         catch (UnsupportedEncodingException e) {
             SurespotLog.w(TAG, e, "error encoding auto invite url");
@@ -336,7 +336,7 @@ public class UIUtils {
 
         String inviteUrl = null;
         try {
-            inviteUrl = "https://server.surespot.me/autoinvite/" + URLEncoder.encode(user, "UTF-8") + "/qr_droid";
+            inviteUrl = SurespotConstants.Url.INVITE_URL + URLEncoder.encode(user, "UTF-8") + "/qr_droid";
         }
         catch (UnsupportedEncodingException e) {
             SurespotLog.w(TAG, e, "error encoding auto invite url");
@@ -369,10 +369,8 @@ public class UIUtils {
         IntentIntegrator integrator = new IntentIntegrator(activity);
         integrator.setDesiredBarcodeFormats(IntentIntegrator.QR_CODE_TYPES);
 
-        integrator.setPrompt("Scan users QR code");
+        integrator.setPrompt("Scan contact QR code");
         integrator.initiateScan();
-
-
     }
 
     public static AlertDialog showHelpDialog(final Activity activity, int titleStringId, View view, final boolean firstTime) {

--- a/surespot/src/main/res/layout/qr_reader_layout.xml
+++ b/surespot/src/main/res/layout/qr_reader_layout.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical" android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+</LinearLayout>

--- a/surespot/src/main/res/layout/qr_reader_layout.xml
+++ b/surespot/src/main/res/layout/qr_reader_layout.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical" android:layout_width="match_parent"
-    android:layout_height="match_parent">
-
-</LinearLayout>

--- a/surespot/src/main/res/values/strings.xml
+++ b/surespot/src/main/res/values/strings.xml
@@ -365,4 +365,5 @@
     <string name="black">black</string>
     <string name="requires_force_stop">requires force stop or reboot to take effect</string>
     <string name="unknown_message_mime_type">unknown message mime type</string>
+    <string name="qr_scan_invalid">Invalid QR code</string>
 </resources>

--- a/surespotcommon/src/main/java/com/twofours/surespot/common/SurespotConstants.java
+++ b/surespotcommon/src/main/java/com/twofours/surespot/common/SurespotConstants.java
@@ -111,6 +111,10 @@ public class SurespotConstants {
 		public final static int WRITE_EXTERNAL_STORAGE = 20;
 		public final static int QR_CODE_NOTIFICATION = 49374;
 	}
+
+	public class Url{
+		public final static String INVITE_URL = "https://server.surespot.me/autoinvite/";
+	}
 	
 	
 	public class Products {

--- a/surespotcommon/src/main/java/com/twofours/surespot/common/SurespotConstants.java
+++ b/surespotcommon/src/main/java/com/twofours/surespot/common/SurespotConstants.java
@@ -109,6 +109,7 @@ public class SurespotConstants {
 		public final static int UNSENT_MESSAGE_NOTIFICATION = 18;
 		public final static int READ_EXTERNAL_STORAGE = 19;
 		public final static int WRITE_EXTERNAL_STORAGE = 20;
+		public final static int QR_CODE_NOTIFICATION = 49374;
 	}
 	
 	


### PR DESCRIPTION
Implemented a simple QR scanner using the ZXING library.  Accessed by the insert contact button when no contact name is present in the field.  

Simply uses the contact name of the QR code to populate the field, proceeding with the invite process from that point in the same manner as if the name had been manually entered.