### PR TITLE
Fix notification LED and add notification custom sound

### DIFF
--- a/surespot/src/main/java/com/twofours/surespot/activities/SettingsActivity.java
+++ b/surespot/src/main/java/com/twofours/surespot/activities/SettingsActivity.java
@@ -273,7 +273,7 @@ public class SettingsActivity extends PreferenceActivity {
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        if (resultCode == RESULT_OK) {
+        if (resultCode == RESULT_OK && requestCode == SurespotConstants.IntentRequestCodes.REQUEST_EXISTING_IMAGE) {
             Uri uri = data.getData();
 
             File imageFile = compressImage(uri, -1);
@@ -296,6 +296,7 @@ public class SettingsActivity extends PreferenceActivity {
                 SurespotConfiguration.setBackgroundImageSet(true);
             }
         }
+        super.onActivityResult(requestCode, resultCode, data);
     }
 
     private File compressImage(final Uri uri, final int rotate) {

--- a/surespot/src/main/java/com/twofours/surespot/chat/ChatController.java
+++ b/surespot/src/main/java/com/twofours/surespot/chat/ChatController.java
@@ -3042,9 +3042,10 @@ public class ChatController {
         int defaults = 0;
 
         boolean showLights = pm == null ? true : pm.getBoolean("pref_notifications_led", true);
-        boolean makeSound = pm == null ? true : pm.getBoolean("pref_notifications_sound", true);
         boolean vibrate = pm == null ? true : pm.getBoolean("pref_notifications_vibration", true);
         int color = pm == null ? 0xff0000FF : pm.getInt("pref_notification_color", ContextCompat.getColor(mContext, R.color.surespotBlue));
+        String customSound = pm == null ? "content://settings/system/notification_sound"
+                : pm.getString("pref_notifications_sound", "content://settings/system/notification_sound");
 
         if (showLights) {
             SurespotLog.v(TAG, "showing notification led");
@@ -3053,10 +3054,8 @@ public class ChatController {
             mBuilder.setLights(color, 0, 0);
         }
 
-        if (makeSound) {
-            SurespotLog.v(TAG, "making notification sound");
-            defaults |= Notification.DEFAULT_SOUND;
-        }
+        SurespotLog.v(TAG, "making notification sound " + customSound);
+        mBuilder.setSound(Uri.parse(customSound));
 
         if (vibrate) {
             SurespotLog.v(TAG, "vibrating notification");

--- a/surespot/src/main/java/com/twofours/surespot/chat/ChatController.java
+++ b/surespot/src/main/java/com/twofours/surespot/chat/ChatController.java
@@ -13,6 +13,7 @@ import android.os.Handler;
 import android.os.Looper;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.TaskStackBuilder;
+import android.support.v4.content.ContextCompat;
 import android.support.v4.view.ViewPager;
 import android.text.SpannableStringBuilder;
 import android.text.TextUtils;
@@ -3043,12 +3044,11 @@ public class ChatController {
         boolean showLights = pm == null ? true : pm.getBoolean("pref_notifications_led", true);
         boolean makeSound = pm == null ? true : pm.getBoolean("pref_notifications_sound", true);
         boolean vibrate = pm == null ? true : pm.getBoolean("pref_notifications_vibration", true);
-        int color = pm == null ? 0xff0000FF : pm.getInt("pref_notification_color", mContext.getResources().getColor(R.color.surespotBlue));
+        int color = pm == null ? 0xff0000FF : pm.getInt("pref_notification_color", ContextCompat.getColor(mContext, R.color.surespotBlue));
 
         if (showLights) {
             SurespotLog.v(TAG, "showing notification led");
             mBuilder.setLights(color, 500, 5000);
-            defaults |= Notification.FLAG_SHOW_LIGHTS;
         } else {
             mBuilder.setLights(color, 0, 0);
         }
@@ -3064,7 +3064,10 @@ public class ChatController {
         }
 
         mBuilder.setDefaults(defaults);
-        mNotificationManager.notify(SurespotConstants.ExtraNames.UNSENT_MESSAGES, SurespotConstants.IntentRequestCodes.UNSENT_MESSAGE_NOTIFICATION, mBuilder.build());
+        Notification notification = mBuilder.build();
+        if (showLights)
+            notification.flags = Notification.FLAG_SHOW_LIGHTS;
+        mNotificationManager.notify(SurespotConstants.ExtraNames.UNSENT_MESSAGES, SurespotConstants.IntentRequestCodes.UNSENT_MESSAGE_NOTIFICATION, notification);
 
         // mNotificationManager.notify(tag, id, mBuilder.build());
         // Notification notification = UIUtils.generateNotification(mBuilder, contentIntent, getPackageName(), title, message);

--- a/surespot/src/main/java/com/twofours/surespot/services/SurespotGcmListenerService.java
+++ b/surespot/src/main/java/com/twofours/surespot/services/SurespotGcmListenerService.java
@@ -27,6 +27,7 @@ import android.os.Bundle;
 import android.os.PowerManager;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.TaskStackBuilder;
+import android.support.v4.content.ContextCompat;
 import android.text.TextUtils;
 
 import com.google.android.gms.gcm.GcmListenerService;
@@ -288,12 +289,11 @@ public class SurespotGcmListenerService extends GcmListenerService {
         boolean showLights = pm.getBoolean("pref_notifications_led", true);
         boolean makeSound = pm.getBoolean("pref_notifications_sound", true);
         boolean vibrate = pm.getBoolean("pref_notifications_vibration", true);
-        int color = pm.getInt("pref_notification_color", getResources().getColor(R.color.surespotBlue));
+        int color = pm.getInt("pref_notification_color", ContextCompat.getColor(context, R.color.surespotBlue));
 
         if (showLights) {
             SurespotLog.v(TAG, "showing notification led");
             mBuilder.setLights(color, 500, 5000);
-            defaults |= Notification.FLAG_SHOW_LIGHTS; // shouldn't need this - setLights does it.  Just to make sure though...
         }
         else {
             mBuilder.setLights(color, 0, 0);
@@ -310,7 +310,10 @@ public class SurespotGcmListenerService extends GcmListenerService {
         }
 
         mBuilder.setDefaults(defaults);
-        mNotificationManager.notify(tag, id, mBuilder.build());
+        Notification notification = mBuilder.build();
+        if (showLights)
+            notification.flags = Notification.FLAG_SHOW_LIGHTS;
+        mNotificationManager.notify(tag, id, notification);
     }
 
     private void generateSystemNotification(Context context, String title, String message, String tag, int id) {

--- a/surespot/src/main/java/com/twofours/surespot/services/SurespotGcmListenerService.java
+++ b/surespot/src/main/java/com/twofours/surespot/services/SurespotGcmListenerService.java
@@ -29,6 +29,7 @@ import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.TaskStackBuilder;
 import android.support.v4.content.ContextCompat;
 import android.text.TextUtils;
+import android.net.Uri;
 
 import com.google.android.gms.gcm.GcmListenerService;
 import com.twofours.surespot.R;
@@ -287,9 +288,9 @@ public class SurespotGcmListenerService extends GcmListenerService {
         int defaults = 0;
 
         boolean showLights = pm.getBoolean("pref_notifications_led", true);
-        boolean makeSound = pm.getBoolean("pref_notifications_sound", true);
         boolean vibrate = pm.getBoolean("pref_notifications_vibration", true);
         int color = pm.getInt("pref_notification_color", ContextCompat.getColor(context, R.color.surespotBlue));
+        String customSound = pm.getString("pref_notifications_sound", "content://settings/system/notification_sound");
 
         if (showLights) {
             SurespotLog.v(TAG, "showing notification led");
@@ -299,10 +300,8 @@ public class SurespotGcmListenerService extends GcmListenerService {
             mBuilder.setLights(color, 0, 0);
         }
 
-        if (makeSound) {
-            SurespotLog.v(TAG, "making notification sound");
-            defaults |= Notification.DEFAULT_SOUND;
-        }
+        SurespotLog.v(TAG, "making notification sound " + customSound);
+        mBuilder.setSound(Uri.parse(customSound));
 
         if (vibrate) {
             SurespotLog.v(TAG, "vibrating notification");

--- a/surespot/src/main/res/xml/preferences.xml
+++ b/surespot/src/main/res/xml/preferences.xml
@@ -43,14 +43,6 @@
             android:key="pref_background_image"
             android:title="@string/pref_title_background_image_select"/>
 
-        <net.margaritov.preference.colorpicker.ColorPickerPreference
-            alphaSlider="false"
-            android:defaultValue="@color/surespotBlue"
-            android:key="pref_notification_color"
-            android:summary="@string/pref_summary_notification_color"
-            android:title="@string/pref_title_notification_color"
-            />
-
         <PreferenceScreen android:title="@string/notifications_title">
             <CheckBoxPreference
                 android:defaultValue="true"
@@ -73,6 +65,12 @@
                 android:dependency="pref_notifications_enabled"
                 android:key="pref_notifications_led"
                 android:title="@string/notifications_led"/>
+            <net.margaritov.preference.colorpicker.ColorPickerPreference
+                alphaSlider="false"
+                android:defaultValue="@color/surespotBlue"
+                android:key="pref_notification_color"
+                android:summary="@string/pref_summary_notification_color"
+                android:title="@string/pref_title_notification_color"/>
         </PreferenceScreen>
 
         <CheckBoxPreference

--- a/surespot/src/main/res/xml/preferences.xml
+++ b/surespot/src/main/res/xml/preferences.xml
@@ -56,11 +56,13 @@
                 android:defaultValue="true"
                 android:key="pref_notifications_enabled"
                 android:title="@string/notifications_enabled"/>
-            <CheckBoxPreference
-                android:defaultValue="true"
+            <RingtonePreference
+                android:defaultValue="content://settings/system/notification_sound"
                 android:dependency="pref_notifications_enabled"
                 android:key="pref_notifications_sound"
-                android:title="@string/notifications_sound"/>
+                android:title="@string/notifications_sound"
+                android:ringtoneType="notification"
+                android:showDefault="true"/>
             <CheckBoxPreference
                 android:defaultValue="true"
                 android:dependency="pref_notifications_enabled"


### PR DESCRIPTION
Probably related to #107, as the flag `FLAG_SHOW_LIGHTS`was being applied to `defaults`, and it has the same constant value as `DEFAULT_SOUND`.
Related to #54.