### PR TITLE
Fixing #98 - notifying user past backups work

### DIFF
--- a/surespot/src/main/java/com/twofours/surespot/identity/ChangePasswordActivity.java
+++ b/surespot/src/main/java/com/twofours/surespot/identity/ChangePasswordActivity.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.graphics.Color;
 import android.os.AsyncTask;
 import android.os.Bundle;
+import android.support.design.widget.Snackbar;
 import android.text.InputFilter;
 import android.text.Spannable;
 import android.text.SpannableString;
@@ -212,7 +213,7 @@ public class ChangePasswordActivity extends Activity {
                                                             newPassword, result.salt);
                                                     resetFields();
                                                     mMpd.decrProgress();
-                                                    Utils.makeLongToast(ChangePasswordActivity.this, getString(R.string.password_changed));
+                                                    Utils.makeLongToast(ChangePasswordActivity.this, getString(R.string.password_changed) + " - " + getString(R.string.password_changed_past_backups));
                                                     Intent intent = new Intent(ChangePasswordActivity.this, ExportIdentityActivity.class);
                                                     intent.putExtra("backupUsername", username);
                                                     ChangePasswordActivity.this.startActivity(intent);

--- a/surespot/src/main/res/values-de/strings.xml
+++ b/surespot/src/main/res/values-de/strings.xml
@@ -196,6 +196,7 @@
   <string name="change_password_progress">Passwort wird geändert</string>
   <string name="could_not_change_password">Passwort konnte nicht geändert werden</string>
   <string name="password_changed">Passwort wurde geändert, bitte erneut Backup erstellen</string>
+  <string name="password_changed_past_backups">Frühere Sicherungen funktionieren weiterhin mit dem alten Kennwort.</string>
   <string name="delete">löschen</string>
   <string name="delete_identity_progress">Profil löschen</string>
   <string name="could_not_delete_identity">Profil konnte nicht gelöscht werden</string>

--- a/surespot/src/main/res/values-es/strings.xml
+++ b/surespot/src/main/res/values-es/strings.xml
@@ -190,6 +190,7 @@
   <string name="change_password_progress">Cambiando contraseña</string>
   <string name="could_not_change_password">No se ha podido cambiar la contraseña</string>
   <string name="password_changed">Contraseña cambiada, por favor haz una copia de seguridad del perfíl</string>
+  <string name="password_changed_past_backups">Las copias de seguridad anteriores seguirán funcionando con la contraseña anterior.</string>
   <string name="delete">borrar</string>
   <string name="delete_identity_progress">Borrando perfil</string>
   <string name="could_not_delete_identity">No se ha podido borrar el perfil</string>

--- a/surespot/src/main/res/values-fr/strings.xml
+++ b/surespot/src/main/res/values-fr/strings.xml
@@ -187,6 +187,7 @@
     <string name="change_password_progress">changement du mot de passe</string>
     <string name="could_not_change_password">impossible de changer le mot de passe</string>
     <string name="password_changed">mot de passe changé, veuillez sauvegarder l\'identité</string>
+    <string name="password_changed_past_backups">Les sauvegardes antérieures fonctionneront toujours avec l\'ancien mot de passe.</string>
     <string name="delete">supprimer</string>
     <string name="delete_identity_progress">supression de l\'identité</string>
     <string name="could_not_delete_identity">impossible de supprimer l\'identité</string>

--- a/surespot/src/main/res/values-it/strings.xml
+++ b/surespot/src/main/res/values-it/strings.xml
@@ -186,6 +186,7 @@
   <string name="change_password_progress">Cambio password in corso</string>
   <string name="could_not_change_password">Cambio password non riuscito</string>
   <string name="password_changed">Password cambiata, esegui il backup dell\'identità</string>
+  <string name="password_changed_past_backups">I backup precedenti continueranno a funzionare con la vecchia password.</string>
   <string name="delete">Cancella</string>
   <string name="delete_identity_progress">Cancellazione identità</string>
   <string name="could_not_delete_identity">Cancellazione identità non riuscita</string>

--- a/surespot/src/main/res/values/strings.xml
+++ b/surespot/src/main/res/values/strings.xml
@@ -199,6 +199,7 @@
     <string name="change_password_progress">Changing password</string>
     <string name="could_not_change_password">Could not change password</string>
     <string name="password_changed">Password changed, please backup the identity</string>
+    <string name="password_changed_past_backups">Past backups still work with the old password</string>
     <string name="delete">Delete</string>
     <string name="delete_identity_progress">Deleting identity</string>
     <string name="could_not_delete_identity">Could not delete identity</string>


### PR DESCRIPTION
Fixed Issue #98 Password Change - "Have the UI notify users upon a password change that past backups will still work with the old password."