### PR TITLE
Fixing Issue #52 Location Share

### DIFF
--- a/surespot/src/main/AndroidManifest.xml
+++ b/surespot/src/main/AndroidManifest.xml
@@ -13,6 +13,8 @@
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="com.android.vending.BILLING" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission. ACCESS_COARSE_LOCATION" />
 
     <uses-feature
         android:name="android.hardware.camera"

--- a/surespot/src/main/java/com/twofours/surespot/chat/ChatFragment.java
+++ b/surespot/src/main/java/com/twofours/surespot/chat/ChatFragment.java
@@ -209,7 +209,10 @@ public class ChatFragment extends Fragment {
         }
         LocationManager locationManager = (LocationManager) getContext().getSystemService(LOCATION_SERVICE);
         boolean isGPSEnabled = locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER);
-        if (!isGPSEnabled) return;
+        if (!isGPSEnabled) {
+            Utils.makeLongToast(getContext(), getString(R.string.share_location_error));
+            return;
+        }
         locationManager.requestLocationUpdates(LocationManager.GPS_PROVIDER, 1, 1, new LocationListener() {
             @Override
             public void onLocationChanged(Location location) {

--- a/surespot/src/main/java/com/twofours/surespot/identity/ChangePasswordActivity.java
+++ b/surespot/src/main/java/com/twofours/surespot/identity/ChangePasswordActivity.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.graphics.Color;
 import android.os.AsyncTask;
 import android.os.Bundle;
+import android.support.design.widget.Snackbar;
 import android.text.InputFilter;
 import android.text.Spannable;
 import android.text.SpannableString;
@@ -212,7 +213,7 @@ public class ChangePasswordActivity extends Activity {
                                                             newPassword, result.salt);
                                                     resetFields();
                                                     mMpd.decrProgress();
-                                                    Utils.makeLongToast(ChangePasswordActivity.this, getString(R.string.password_changed));
+                                                    Utils.makeLongToast(ChangePasswordActivity.this, getString(R.string.password_changed) + " - " + getString(R.string.password_changed_past_backups));
                                                     Intent intent = new Intent(ChangePasswordActivity.this, ExportIdentityActivity.class);
                                                     intent.putExtra("backupUsername", username);
                                                     ChangePasswordActivity.this.startActivity(intent);

--- a/surespot/src/main/res/layout/chat_fragment.xml
+++ b/surespot/src/main/res/layout/chat_fragment.xml
@@ -5,6 +5,13 @@
               android:layout_height="match_parent"
               android:orientation="vertical">
 
+    <Button
+        android:id="@+id/share_location"
+        android:layout_gravity="center"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/share_location" />
+
     <ListView
         android:id="@+id/message_list"
         android:layout_width="match_parent"

--- a/surespot/src/main/res/values-de/strings.xml
+++ b/surespot/src/main/res/values-de/strings.xml
@@ -196,6 +196,7 @@
   <string name="change_password_progress">Passwort wird geändert</string>
   <string name="could_not_change_password">Passwort konnte nicht geändert werden</string>
   <string name="password_changed">Passwort wurde geändert, bitte erneut Backup erstellen</string>
+  <string name="password_changed_past_backups">Frühere Sicherungen funktionieren weiterhin mit dem alten Kennwort.</string>
   <string name="delete">löschen</string>
   <string name="delete_identity_progress">Profil löschen</string>
   <string name="could_not_delete_identity">Profil konnte nicht gelöscht werden</string>

--- a/surespot/src/main/res/values-de/strings.xml
+++ b/surespot/src/main/res/values-de/strings.xml
@@ -196,7 +196,8 @@
   <string name="change_password_progress">Passwort wird geändert</string>
   <string name="could_not_change_password">Passwort konnte nicht geändert werden</string>
   <string name="password_changed">Passwort wurde geändert, bitte erneut Backup erstellen</string>
-  <string name="password_changed_past_backups">Frühere Sicherungen funktionieren weiterhin mit dem alten Kennwort.</string>
+  <string name="share_location">Ort teilen</string>
+  <string name="share_location_error">Fehler - Stellen Sie sicher, dass GPS eingeschaltet ist, und Sie haben die Berechtigung in den Einstellungen gegeben</string>
   <string name="delete">löschen</string>
   <string name="delete_identity_progress">Profil löschen</string>
   <string name="could_not_delete_identity">Profil konnte nicht gelöscht werden</string>

--- a/surespot/src/main/res/values-es/strings.xml
+++ b/surespot/src/main/res/values-es/strings.xml
@@ -190,7 +190,8 @@
   <string name="change_password_progress">Cambiando contraseña</string>
   <string name="could_not_change_password">No se ha podido cambiar la contraseña</string>
   <string name="password_changed">Contraseña cambiada, por favor haz una copia de seguridad del perfíl</string>
-  <string name="password_changed_past_backups">Las copias de seguridad anteriores seguirán funcionando con la contraseña anterior.</string>
+  <string name="share_location">Comparte ubicacion</string>
+  <string name="share_location_error">Error: asegúrese de que el GPS esté encendido y le haya dado permiso en la configuración</string>
   <string name="delete">borrar</string>
   <string name="delete_identity_progress">Borrando perfil</string>
   <string name="could_not_delete_identity">No se ha podido borrar el perfil</string>

--- a/surespot/src/main/res/values-es/strings.xml
+++ b/surespot/src/main/res/values-es/strings.xml
@@ -190,6 +190,7 @@
   <string name="change_password_progress">Cambiando contraseña</string>
   <string name="could_not_change_password">No se ha podido cambiar la contraseña</string>
   <string name="password_changed">Contraseña cambiada, por favor haz una copia de seguridad del perfíl</string>
+  <string name="password_changed_past_backups">Las copias de seguridad anteriores seguirán funcionando con la contraseña anterior.</string>
   <string name="delete">borrar</string>
   <string name="delete_identity_progress">Borrando perfil</string>
   <string name="could_not_delete_identity">No se ha podido borrar el perfil</string>

--- a/surespot/src/main/res/values-fr/strings.xml
+++ b/surespot/src/main/res/values-fr/strings.xml
@@ -187,6 +187,7 @@
     <string name="change_password_progress">changement du mot de passe</string>
     <string name="could_not_change_password">impossible de changer le mot de passe</string>
     <string name="password_changed">mot de passe changé, veuillez sauvegarder l\'identité</string>
+    <string name="password_changed_past_backups">Les sauvegardes antérieures fonctionneront toujours avec l\'ancien mot de passe.</string>
     <string name="delete">supprimer</string>
     <string name="delete_identity_progress">supression de l\'identité</string>
     <string name="could_not_delete_identity">impossible de supprimer l\'identité</string>

--- a/surespot/src/main/res/values-fr/strings.xml
+++ b/surespot/src/main/res/values-fr/strings.xml
@@ -187,7 +187,8 @@
     <string name="change_password_progress">changement du mot de passe</string>
     <string name="could_not_change_password">impossible de changer le mot de passe</string>
     <string name="password_changed">mot de passe changé, veuillez sauvegarder l\'identité</string>
-    <string name="password_changed_past_backups">Les sauvegardes antérieures fonctionneront toujours avec l\'ancien mot de passe.</string>
+    <string name="share_location">Emplacement partagé</string>
+    <string name="share_location_error">Erreur - Assurez-vous que GPS est activé et que vous avez donné la permission dans les paramètres</string>
     <string name="delete">supprimer</string>
     <string name="delete_identity_progress">supression de l\'identité</string>
     <string name="could_not_delete_identity">impossible de supprimer l\'identité</string>

--- a/surespot/src/main/res/values-it/strings.xml
+++ b/surespot/src/main/res/values-it/strings.xml
@@ -186,6 +186,7 @@
   <string name="change_password_progress">Cambio password in corso</string>
   <string name="could_not_change_password">Cambio password non riuscito</string>
   <string name="password_changed">Password cambiata, esegui il backup dell\'identità</string>
+  <string name="password_changed_past_backups">I backup precedenti continueranno a funzionare con la vecchia password.</string>
   <string name="delete">Cancella</string>
   <string name="delete_identity_progress">Cancellazione identità</string>
   <string name="could_not_delete_identity">Cancellazione identità non riuscita</string>

--- a/surespot/src/main/res/values-it/strings.xml
+++ b/surespot/src/main/res/values-it/strings.xml
@@ -186,7 +186,8 @@
   <string name="change_password_progress">Cambio password in corso</string>
   <string name="could_not_change_password">Cambio password non riuscito</string>
   <string name="password_changed">Password cambiata, esegui il backup dell\'identità</string>
-  <string name="password_changed_past_backups">I backup precedenti continueranno a funzionare con la vecchia password.</string>
+  <string name="share_location">Condividi posizione</string>
+  <string name="share_location_error">ERROR - Assicurarsi che il GPS sia acceso e hai dato il permesso nelle impostazioni</string>
   <string name="delete">Cancella</string>
   <string name="delete_identity_progress">Cancellazione identità</string>
   <string name="could_not_delete_identity">Cancellazione identità non riuscita</string>

--- a/surespot/src/main/res/values/strings.xml
+++ b/surespot/src/main/res/values/strings.xml
@@ -199,6 +199,7 @@
     <string name="change_password_progress">Changing password</string>
     <string name="could_not_change_password">Could not change password</string>
     <string name="password_changed">Password changed, please backup the identity</string>
+    <string name="password_changed_past_backups">Past backups still work with the old password</string>
     <string name="delete">Delete</string>
     <string name="delete_identity_progress">Deleting identity</string>
     <string name="could_not_delete_identity">Could not delete identity</string>

--- a/surespot/src/main/res/values/strings.xml
+++ b/surespot/src/main/res/values/strings.xml
@@ -199,7 +199,8 @@
     <string name="change_password_progress">Changing password</string>
     <string name="could_not_change_password">Could not change password</string>
     <string name="password_changed">Password changed, please backup the identity</string>
-    <string name="password_changed_past_backups">Past backups still work with the old password</string>
+    <string name="share_location">Share Location</string>
+    <string name="share_location_error">Error - be sure GPS is on and you have given permission in Settings, then try again</string>
     <string name="delete">Delete</string>
     <string name="delete_identity_progress">Deleting identity</string>
     <string name="could_not_delete_identity">Could not delete identity</string>


### PR DESCRIPTION
Fixing issue #52 Feature Request: Location share

The app contains the necessary logic and permissions-related code to work with location with a sample button (which position and exact user experience might be reconsidered - or be left as-is -  by the project owners), sharing location to the clipboard for easy access (and pasting) while chatting with someone, without the need to exit the app and open another maps / GPS app to get the current, precise location.