### PR TITLE
Fixing issue #31 wrong persistence of draft text

### DIFF
--- a/surespot/src/main/java/com/twofours/surespot/activities/MainActivity.java
+++ b/surespot/src/main/java/com/twofours/surespot/activities/MainActivity.java
@@ -545,6 +545,7 @@ public class MainActivity extends FragmentActivity implements EmojiconsView.OnEm
         });
 
         mEtMessage = mainView.findViewById(R.id.etMessage);
+        mEtMessage.setText("");
         mEtMessage.setOnEditorActionListener(new OnEditorActionListener() {
             @Override
             public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {


### PR DESCRIPTION
Fixing issue #31 associating entered text with the current contact
In fact, the entered text is being associated with the current contact, but due to automatic UI state management on Android, the text might have been persisted, even when another contact page is opened (which doesn't have a previously saved draft message); by setting the text of the text box to "", the problem is then removed.